### PR TITLE
add missing prefix to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Additional CLI options that must be appended to the minio server start command.
 
 Minio access and secret keys.
 
-    skip_server: False
-    skip_client: False
+    minio_skip_server: False
+    minio_skip_client: False
 
 Switches to disable minio server and/or minio client installation.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,5 +25,5 @@ minio_access_key: ""
 minio_secret_key: ""
 
 # Switches to disable minio server and/or minio client installation
-skip_server: False
-skip_client: False
+minio_skip_server: False
+minio_skip_client: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     shell: /bin/bash
 
 - include: server.yml
-  when: not skip_server
+  when: not minio_skip_server
 
 - include: client.yml
-  when: not skip_client
+  when: not minio_skip_client


### PR DESCRIPTION
This prevents collision with variables from other roles.