### PR TITLE
major code cleanup

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: download minio client
   get_url:
     url: "{{ minio_client_download_url }}"

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -3,6 +3,6 @@
   get_url:
     url: "{{ minio_client_download_url }}"
     dest: "{{ minio_client_bin }}"
-    owner: "{{ minio_user }}"
-    group: "{{ minio_group }}"
+    owner: "root"
+    group: "root"
     mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,31 +1,19 @@
 ---
-
 - name: include os-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
-  # add the python sni support to legacy python installations
-- include: python_sni.yml
-  when: ansible_os_family == 'Debian'
-    and ansible_python_version is version_compare('2.6.0', '>=')
-    and ansible_python_version is version_compare('2.7.9', '<')
+- name: add the python sni support to legacy python installations
+  include: python_sni.yml
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_python_version is version_compare('2.6.0', '>=')
+    - ansible_python_version is version_compare('2.7.9', '<')
 
-  # install additional ansible dependencies
 - name: install ansible support packages
   package:
     name: "{{ item }}"
     state: present
-  with_items: "{{ ansible_support_packages }}"
-
-- name: create minio group
-  group:
-    name: "{{ minio_group }}"
-    state: present
-
-- name: create minio user
-  user:
-    name: "{{ minio_user }}"
-    group: "{{ minio_group }}"
-    shell: /bin/bash
+  with_items: "{{ minio_ansible_support_packages }}"
 
 - include: server.yml
   when: minio_install_server

--- a/tasks/python_sni.yml
+++ b/tasks/python_sni.yml
@@ -1,12 +1,9 @@
 ---
-
-# with_indexed_items is required as a workaround for this issue:
-# https://github.com/ansible/ansible-modules-core/issues/1178
 - name: install python-pip
   package:
-    name: "{{ item.1 }}"
+    name: "{{ item }}"
     state: present
-  with_indexed_items: "{{ python_pip_packages }}"
+  with_items: "{{ python_pip_packages }}"
 
 - name: install the Python SNI support packages
   package:
@@ -21,4 +18,7 @@
   pip:
     name: "{{ item }}"
     state: present
-  with_items: "{{ python_sni_pip_dependencies }}"
+  with_items:
+    - pyopenssl
+    - ndg-httpsclient
+    - pyasn1

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,4 +1,14 @@
 ---
+- name: create minio group
+  group:
+    name: "{{ minio_group }}"
+    state: present
+
+- name: create minio user
+  user:
+    name: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    shell: /bin/bash
 
 - name: create data storage directories
   file:
@@ -27,13 +37,13 @@
 - name: create the minio server systemd config
   template:
     src: minio.service.j2
-    dest: "{{ systemd_units_dir }}/minio.service"
+    dest: "/etc/systemd/system/minio.service"
   when: ansible_service_mgr == "systemd"
 
 - name: create the minio server init.d config
   template:
     src: minio.init.j2
-    dest: "{{ initd_conf_dir }}/minio"
+    dest: "/etc/init.d/minio"
     mode: 0750
   when: ansible_service_mgr != "systemd"
 

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -24,8 +24,8 @@
   get_url:
     url: "{{ minio_server_download_url }}"
     dest: "{{ minio_server_bin }}"
-    owner: "{{ minio_user }}"
-    group: "{{ minio_group }}"
+    owner: "root"
+    group: "root"
     mode: 0755
 
 - name: generate the minio server envfile

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,8 +1,4 @@
 ---
-
-# systemd unit files location
-systemd_units_dir: /lib/systemd/system
-
 # packages providing python-pip
 python_pip_packages:
   - python-pip
@@ -14,5 +10,5 @@ python_sni_support_packages:
   - libffi-dev
 
 # extra packages needed by ansible to correctly configure the system
-ansible_support_packages:
+minio_ansible_support_packages:
   - ca-certificates

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,8 +1,4 @@
 ---
-
-# systemd unit files location
-systemd_units_dir: /etc/systemd/system
-
 # packages providing python-pip
 python_pip_packages:
   - epel-release
@@ -12,4 +8,4 @@ python_pip_packages:
 python_sni_support_packages: [ ]
 
 # extra packages needed by ansible to correctly configure the system
-ansible_support_packages: [ ]
+minio_ansible_support_packages: [ ]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,12 +3,3 @@
 # Minio and MC download urls
 minio_server_download_url: https://dl.minio.io/server/minio/release/linux-amd64/minio
 minio_client_download_url: https://dl.minio.io/client/mc/release/linux-amd64/mc
-
-# default init scripts location
-initd_conf_dir: /etc/init.d
-
-# python pip packages required to support SNI certificates
-python_sni_pip_dependencies:
-  - pyopenssl
-  - ndg-httpsclient
-  - pyasn1


### PR DESCRIPTION
- to increase security binary files should be owned by root not by user who executes that file
- move user and group creation to `server` section as those aren't needed when only installing client
- remove hacky installation of packages (do not use `with_indexed_items`)
- rename `ansible_support_packages` to `minio_ansible_support_packages` as every variable starting from `ansible_` should come from ansible itself, not from role.
- remove `python_sni_pip_dependencies` and just list packages in task for better readability
- remove `systemd_units_dir` and always use `/etc/systemd/system` value as is recommended by systemd
- remove `initd_conf_dir` variable and only use its value for better readability