### PR TITLE
Multiarch

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: preflight.yml
+
 - name: add the python sni support to legacy python installations
   include: python_sni.yml
   when:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,12 @@
+---
+- name: Compose Minio download url
+  set_fact:
+    minio_server_download_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/minio"
+  when:
+    - minio_install_server
+
+- name: Compose MC download url
+  set_fact:
+    minio_client_download_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/mc"
+  when:
+    - minio_install_client

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,7 @@
 ---
-
-# Minio and MC download urls
-minio_server_download_url: https://dl.minio.io/server/minio/release/linux-amd64/minio
-minio_client_download_url: https://dl.minio.io/client/mc/release/linux-amd64/mc
+go_arch_map:
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'arm'
+  armv6l: 'arm6vl'


### PR DESCRIPTION
Resolve #9

Dynamically set `minio_server_download_url` and `minio_client_download_url` in runtime based on target host CPU architecture.

Introduce `preflight.yml` where all asserts and set_facts should happen before executing anything on target hosts.