### PR TITLE
Add fedora to supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: Fedora
+      versions:
+        - 27
     - name: Ubuntu
       versions:
         - trusty


### PR DESCRIPTION
We are already running tests on fedora, so why not add it to meta informations? :smile: