### PR TITLE
Add option to create minio clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ minio_server_make_datadirs: true
 Create directories from `minio_server_datadirs` 
 
 ```yaml
+minio_server_cluster_nodes: [ ]
+```
+
+Set a list of nodes to create a [distributed cluster](https://docs.minio.io/docs/distributed-minio-quickstart-guide).
+
+In this mode, ansible will create your server datadirs, but use this list for the server startup.
+
+Example:
+
+```yaml
+minio_server_datadirs:
+  - '/minio-data'
+minio_server_cluster_nodes:
+  - 'https://server1/minio-data'
+  - 'https://server2/minio-data'
+  - 'https://server3/minio-data'
+```
+
+```yaml
 minio_server_opts: ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,17 +64,19 @@ minio_server_cluster_nodes: [ ]
 
 Set a list of nodes to create a [distributed cluster](https://docs.minio.io/docs/distributed-minio-quickstart-guide).
 
-In this mode, ansible will create your server datadirs, but use this list for the server startup.
+In this mode, ansible will create your server datadirs, but use this list for the server startup. Note you will need a number of disks to satisfy Minio's distributed storage requirements.
 
 Example:
 
 ```yaml
 minio_server_datadirs:
   - '/minio-data'
+  - ...
 minio_server_cluster_nodes:
   - 'https://server1/minio-data'
   - 'https://server2/minio-data'
   - 'https://server3/minio-data'
+  - ...
 ```
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,9 @@ minio_server_addr: ":9091"
 minio_server_datadirs: [ ]
 minio_server_make_datadirs: true
 
+# Minio server cluster node list.
+minio_server_cluster_nodes: [ ]
+
 # Additional minio server CLI options
 minio_server_opts: ""
 

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -1,0 +1,51 @@
+---
+driver:
+  name: docker
+lint:
+  name: yamllint
+
+platforms:
+  - name: minio-centos-7
+    image: paulfantom/centos-molecule:7
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: minio-fedora-27
+    image: paulfantom/fedora-molecule:27
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: minio-debian-9
+    image: paulfantom/debian-molecule:9
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: minio-ubuntu-18.04
+    image: paulfantom/ubuntu-molecule:18.04
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: minio-ubuntu-16.04
+    image: paulfantom/ubuntu-molecule:16.04
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    create: ../default/create.yml
+    prepare: ../default/prepare.yml
+    converge: playbook.yml
+    destroy: ../default/destroy.yml
+
+scenario:
+  name: cluster
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    enabled: true

--- a/molecule/cluster/playbook.yml
+++ b/molecule/cluster/playbook.yml
@@ -6,6 +6,12 @@
     - ansible-minio
   vars:
     minio_server_datadirs:
-      - "/test"
+      - "/test1"
+      - "/test2"
+      - "/test3"
+      - "/test4"
     minio_server_cluster_nodes:
-      - "https://172.17.0.2:9091/test"
+      - "http://{{ ansible_hostname }}:9091/test1"
+      - "http://{{ ansible_hostname }}:9091/test2"
+      - "http://{{ ansible_hostname }}:9091/test3"
+      - "http://{{ ansible_hostname }}:9091/test4"

--- a/molecule/cluster/playbook.yml
+++ b/molecule/cluster/playbook.yml
@@ -1,0 +1,11 @@
+---
+
+- hosts: all
+  any_errors_fatal: true
+  roles:
+    - ansible-minio
+  vars:
+    minio_server_datadirs:
+      - "/test"
+    minio_server_cluster_nodes:
+      - "https://172.17.0.2:9091/test"

--- a/molecule/cluster/tests/test_minio_cluster.py
+++ b/molecule/cluster/tests/test_minio_cluster.py
@@ -1,0 +1,35 @@
+import yaml
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+@pytest.fixture()
+def AnsibleDefaults(Ansible):
+    with open("./defaults/main.yml", 'r') as stream:
+        return yaml.load(stream)
+
+
+@pytest.mark.parametrize("dirs", [
+    "/minio-test"
+])
+def test_directories(host, dirs):
+    d = host.file(dirs)
+    assert d.is_directory
+    assert d.exists
+    assert d.user == AnsibleDefaults['minio_user']
+    assert d.group == AnsibleDefaults['minio_group']
+    assert oct(d.mode) == '0750'
+
+
+def test_env_file(host):
+    env_file = host.file("/etc/default/minio")
+    assert env_file.contains('MINIO_VOLUMES="https://172.17.0.2:9091/test"')
+
+
+def test_minio_service(Service):
+    s = Service('minio')
+    assert s.is_running
+    assert s.is_enabled

--- a/molecule/cluster/tests/test_minio_cluster.py
+++ b/molecule/cluster/tests/test_minio_cluster.py
@@ -26,7 +26,10 @@ def test_directories(host, dirs):
 
 def test_env_file(host):
     env_file = host.file("/etc/default/minio")
-    assert env_file.contains('MINIO_VOLUMES="https://172.17.0.2:9091/test"')
+    a = host.ansible.get_variables()
+    host = a['ansible_hostname']
+    volume_string = "MINIO_VOLUMES=\"http://%s:9091/test1 " % (host)
+    assert env_file.contains(volume_string)
 
 
 def test_minio_service(Service):

--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -1,7 +1,11 @@
 # {{ ansible_managed }}
 
 # Minio local/remote volumes.
+{% if minio_server_cluster_nodes | length > 0 %}
+MINIO_VOLUMES="{{ minio_server_cluster_nodes | join(' ') }}"
+{% else %}
 MINIO_VOLUMES="{{ minio_server_datadirs | join(' ') }}"
+{% endif %}
 # Minio cli options.
 MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
 


### PR DESCRIPTION
Add a cluster list that overrides the datadirs list, this allows for
local creation of data storage directories separate from a list of
cluster members.