### PR TITLE
Set a default value for the 'minio_server_datadirs' variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ minio_server_addr: ":9091"
 The Minio server listen address.
 
 ```yaml
-minio_server_datadirs: [ ]
+minio_server_datadirs:
+  - /var/lib/minio
 ```
 
 Directories of the folder containing the minio server data
-**NB**: This variable must always be set by the role, otherwise the minio service will not start.
 
 ```yaml
 minio_server_make_datadirs: true
 ```
 
-Create directories from `minio_server_datadirs` 
+Create directories from `minio_server_datadirs`
 
 ```yaml
 minio_server_cluster_nodes: [ ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,18 +4,19 @@
 minio_server_bin: /usr/local/bin/minio
 minio_client_bin: /usr/local/bin/mc
 
-# Runtime user and group for the minio server service
+# Runtime user and group for the Minio server service
 minio_user: minio
 minio_group: minio
 
-# Path to the file containing the ENV variables for the minio server
+# Path to the file containing the ENV variables for the Minio server
 minio_server_envfile: /etc/default/minio
 
 # Minio server listen address
 minio_server_addr: ":9091"
 
 # Minio server data directories
-minio_server_datadirs: [ ]
+minio_server_datadirs:
+  - /var/lib/minio
 minio_server_make_datadirs: true
 
 # Minio server cluster node list.
@@ -24,13 +25,13 @@ minio_server_cluster_nodes: [ ]
 # Additional environment variables to be set in minio server environment
 minio_server_env_extra: ""
 
-# Additional minio server CLI options
+# Additional Minio server CLI options
 minio_server_opts: ""
 
 # Minio access and secret keys
 minio_access_key: ""
 minio_secret_key: ""
 
-# Switches to enable/disable the minio server and/or minio client installation.
+# Switches to enable/disable the Minio server and/or Minio client installation.
 minio_install_server: true
 minio_install_client: true


### PR DESCRIPTION
This PR sets the `minio_server_datadirs` default value to `/var/lib/minio` as discussed in #21.