### PR TITLE
Pin the version of ferrarimarco/github-changelog-generator to prevent the CI from hanging

### DIFF
--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -55,7 +55,7 @@ fi
 # Generate CHANGELOG.md
 git checkout master
 git pull
-docker run -it --rm -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator \
+docker run -it --rm -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator:1.14.3 \
                -u "${ORGANIZATION}" -p "${PROJECT}" --token "${GH_TOKEN}" \
                --release-url "${GALAXY_URL}" \
                --unreleased-label "**Next release**" --no-compare-link


### PR DESCRIPTION
See https://github.com/github-changelog-generator/github-changelog-generator/issues/663.