### PR TITLE
Add become: yes to playbook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ None.
 ```yaml
 - name: "Install Minio"
   hosts: all
+  become: yes
   roles:
-    - { role: atosatto.minio, become: yes }
+    - { role: atosatto.minio }
   vars:
     minio_server_datadirs: [ "/minio-test" ]
 ```

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ None.
 - name: "Install Minio"
   hosts: all
   roles:
-    - atosatto.minio
+    - { role: atosatto.minio, become: yes }
   vars:
     minio_server_datadirs: [ "/minio-test" ]
 ```


### PR DESCRIPTION
I noticed that the example doesn't include a hint that you need to be root. It's sort of obvious since the role attempts to create a minio user and group, but I figured I add it to make it easier for the next person.