### PR TITLE
Fix ansible-lint error on double quote

### DIFF
--- a/molecule/alternative/tests/test_minio_alternative.py
+++ b/molecule/alternative/tests/test_minio_alternative.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open("../../defaults/main.yml", 'r') as stream:
+    with open('../../defaults/main.yml', 'r') as stream:
         return yaml.load(stream)
 
 
@@ -42,4 +42,4 @@ def test_minio_server_data_directories(host, AnsibleDefaults, minio_datadir):
 
 def test_minio_server_webserver(host):
 
-    host.socket("tcp://127.0.0.1:80").is_listening
+    host.socket('tcp://127.0.0.1:80').is_listening

--- a/molecule/cluster/tests/test_minio_cluster.py
+++ b/molecule/cluster/tests/test_minio_cluster.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open("../../defaults/main.yml", 'r') as stream:
+    with open('../../defaults/main.yml', 'r') as stream:
         return yaml.load(stream)
 
 

--- a/molecule/default/tests/test_minio_default.py
+++ b/molecule/default/tests/test_minio_default.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open("../../defaults/main.yml", 'r') as stream:
+    with open('../../defaults/main.yml', 'r') as stream:
         return yaml.load(stream)
 
 
@@ -40,4 +40,4 @@ def test_minio_server_data_directories(host, AnsibleDefaults):
 
 def test_minio_server_webserver(host):
 
-    host.socket("tcp://127.0.0.1:9091").is_listening
+    host.socket('tcp://127.0.0.1:9091').is_listening


### PR DESCRIPTION
On my install, I have this error (which is not in ci)

```
--> Scenario: 'default'
--> Action: 'lint'
--> Executing Yamllint on files found in ansible-minio/...
Lint completed successfully.
--> Executing Flake8 on files found in ansible-minio/molecule/default/tests/...
    ansible-minio/molecule/default/tests/test_minio_default.py:43:17: Q000 Remove bad quotes
An error occurred during the test sequence action: 'lint'. Cleaning up.
```

ansible-lint --version
ansible-lint 4.1.0