### PR TITLE
Allow set multiple extra env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ minio_server_cluster_nodes:
 ```
 
 ```yaml
-minio_server_env_extra: ""
+minio_server_env_extras: []
+minio_server_env_extra: "" # deprecated
 ```
 
 Additional environment variables to be set in Minio server environment

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,8 @@ minio_server_make_datadirs: true
 minio_server_cluster_nodes: [ ]
 
 # Additional environment variables to be set in minio server environment
-minio_server_env_extra: ""
+minio_server_env_extras: [ ]
+minio_server_env_extra: ''  # deprecated
 
 # Additional Minio server CLI options
 minio_server_opts: ""

--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -18,4 +18,8 @@ MINIO_ACCESS_KEY="{{ minio_access_key }}"
 MINIO_SECRET_KEY="{{ minio_secret_key }}"
 {% endif %}
 
+# Extra variables
 {{ minio_server_env_extra }}
+{% for env_extra in minio_server_env_extras %}
+{{ env_extra }}
+{% endfor %}


### PR DESCRIPTION
set ansible var *minio_server_env_extra* to 
`'MINIO_CACHE_DRIVES="/tmp/minio" MINIO_CACHE_MAXUSE=70 MINIO_CACHE_EXPIRY=90'`
gives that line in /etc/default/minio
`MINIO_CACHE_DRIVES="/tmp/minio" MINIO_CACHE_MAXUSE=70 MINIO_CACHE_EXPIRY=90`

that is not well interpreted at start up MINIO_CACHE_DRIVES = `"/tmp/minio MINIO_CACHE_MAXUSE=70 MINIO_CACHE_EXPIRY=90"`

=> Change *minio_server_env_extra* (deprecated) to *minio_server_env_extras* with array value
