### PR TITLE
Option to disable create/update the user/group running minio & add by default create_home: no

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ Can be 'RELEASE.2019-06-27T21-13-50Z' for instance.
 ```yaml
 minio_user: minio
 minio_group: minio
+minio_usergroup_manage: true
 ```
 
-Name and group of the user running the minio server.
-**NB**: This role automatically creates the minio user and/or group if these does not exist in the system.
+Name and group of the user running the minio server. Without explicitly
+disabling `minio_usergroup_manage: false` this role will create/update this
+user and group. The created/updated user will be installed/updated as a system
+user.
 
 ```yaml
 minio_server_envfile: /etc/default/minio

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ minio_client_release: ""
 # Runtime user and group for the Minio server service
 minio_user: minio
 minio_group: minio
+minio_usergroup_manage: true
 
 # Path to the file containing the ENV variables for the Minio server
 minio_server_envfile: /etc/default/minio

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -21,13 +21,16 @@
   group:
     name: "{{ minio_group }}"
     state: present
+  when: minio_usergroup_manage|bool
 
 - name: Create Minio user
   user:
     name: "{{ minio_user }}"
     group: "{{ minio_group }}"
     system: "yes"
+    create_home: no
     shell: "/usr/sbin/nologin"
+  when: minio_usergroup_manage|bool
 
 - name: Create the Minio data storage directories
   file:


### PR DESCRIPTION
Refs #43

---

This pull request allow disable management from this role for the specified `minio_user` and `minio_group` (but by default keep old behavior). The variable used is `minio_usergroup_manage: true` (We could use other name).

This pull request also implement @SuperQ suggestion from https://github.com/atosatto/ansible-minio/issues/15#issuecomment-399982774. So by default if this role have to manage user, it will not try create the home directory.

### About tests:
- Tested master branch on Ubuntu 18.04 plus these changes (the lastest release had a few changes, so I also tested the master on this PR):
  - The default behavior was keep the like before (except by the create folder)
  - Did not tested full new install (but updated)
- molecule tests to check this nea feature where not added to this initial PR.

### Issues to consider when changing in production
> this mote was not added to the readme, but will mention here. But this may be intuitive issue, so maybe will not work mention.

When updating the user/group from this role, consider that not only the data directories, but also a folder named `.minio.sys` at your root data directory may still have the older permissions values and this will make your minio instances restart too quickly. 
