### PR TITLE
Fix startup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,8 @@
     - ansible_python_version is version_compare('2.6.0', '>=')
     - ansible_python_version is version_compare('2.7.9', '<')
 
+- import_tasks: preflight.yml
+
 - include_tasks: install-server.yml
   when: minio_install_server
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,26 @@
+---
+- name: Validate access key
+  fail:
+    msg: "minio_access_key is set but must be at least three characters"
+  when: minio_access_key|length < 3 and minio_access_key|length != 0
+
+- name: Validate secret key
+  fail:
+    msg: "minio_secret_key is set but must be at least 8 characters"
+  when: minio_secret_key|length < 8 and minio_secret_key|length != 0
+
+- name: Setup __minio_volumes (cluster context)
+  set_fact:
+    __minio_volumes: "{{ minio_server_cluster_nodes | join(' ') }}"
+  when:
+    minio_server_cluster_nodes|length > 0
+
+- name: Setup __minio_volumes (single node)
+  set_fact:
+    __minio_volumes: "{{ minio_server_datadirs | join(' ') }}"
+  when: minio_server_datadirs|length > 0 and minio_server_cluster_nodes|length == 0
+
+- name: Validate __minio_volumes
+  fail:
+    msg: "Please set minio_server_cluster_nodes or minio_server_datadirs"
+  when: __minio_volumes|length == 0

--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -1,11 +1,8 @@
 {{ ansible_managed | comment }}
 
 # Minio local/remote volumes.
-{% if minio_server_cluster_nodes | length > 0 %}
-MINIO_VOLUMES="{{ minio_server_cluster_nodes | join(' ') }}"
-{% else %}
-MINIO_VOLUMES="{{ minio_server_datadirs | join(' ') }}"
-{% endif %}
+MINIO_VOLUMES="{{ __minio_volumes }}"
+
 # Minio cli options.
 MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
 

--- a/templates/minio.service.j2
+++ b/templates/minio.service.j2
@@ -20,7 +20,7 @@ Group={{ minio_group }}
 PermissionsStartOnly=true
 
 EnvironmentFile={{ minio_server_envfile }}
-ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] || echo \"Variable MINIO_VOLUMES not set in {{ minio_server_envfile }}\""
+#ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] || echo \"Variable MINIO_VOLUMES not set in {{ minio_server_envfile }}\""
 
 ExecStart={{ minio_server_bin }} server $MINIO_OPTS $MINIO_VOLUMES
 


### PR DESCRIPTION
Hey @atosatto! :) 

I pushed some suggestions to improve startup, one of the things is validation of variables — I introduced a `preflight.yml` with tasks to achieve this. Mostly because `foo` and `bar` as access key and secret key didn't work, and I had to ssh into VMs to see this.

Then the more important "fix" is the removal of your `ExecPreStart=`. Again, I am using CentOS7 and the check failed consistently, though when commented out, Minio would find the variables from the defaults file and start. It seems like it's not possible to use environment variables like this. So I figured might as well do the validation in Ansible vs. the unit.

Let me know what you think.