### PR TITLE
Added option to install minio from repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,6 @@ minio_secret_key: ""
 # Switches to enable/disable the Minio server and/or Minio client installation.
 minio_install_server: true
 minio_install_client: true
+
+# Switches Minio installation source: allowed is one of ['download', 'repo']
+minio_install_source: download

--- a/tasks/install-client.yml
+++ b/tasks/install-client.yml
@@ -28,5 +28,13 @@
     checksum: "sha256:{{ _minio_client_checksum }}"
   register: _download_client
   until: _download_client is succeeded
+  when: minio_install_source == "download"
   retries: 5
   delay: 2
+
+- name: Install the latest version of Minio from a repository
+  ansible.builtin.package:
+    name:
+      - mcli
+    state: latest
+  when: minio_install_source == "repo"

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -49,9 +49,17 @@
     checksum: "sha256:{{ _minio_server_checksum }}"
   register: _download_server
   until: _download_server is succeeded
+  when: minio_install_source == "download"
   retries: 5
   delay: 2
   notify: restart minio
+
+- name: Install the latest version of Minio server from a repository
+  ansible.builtin.package:
+    name:
+      - minio
+    state: latest
+  when: minio_install_source == "repo"
 
 - name: Generate the Minio server envfile
   template:


### PR DESCRIPTION
As we manage all the software in an internal mirror, an option to install from an existing repository has been added.