### PR TITLE
Changing minio access credentials

### DIFF
--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -10,12 +10,12 @@ MINIO_VOLUMES="{{ minio_server_datadirs | join(' ') }}"
 MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
 
 {% if minio_access_key %}
-# Access Key of the server.
-MINIO_ACCESS_KEY="{{ minio_access_key }}"
+# Root user of the server because Access Key of the server has been deprecated.
+MINIO_ROOT_USER="{{ minio_access_key }}"
 {% endif %}
 {% if minio_secret_key %}
-# Secret key of the server.
-MINIO_SECRET_KEY="{{ minio_secret_key }}"
+# Root password of the server because Secret key of the server has been deprecated.
+MINIO_ROOT_PASSWORD="{{ minio_secret_key }}"
 {% endif %}
 
 {{ minio_server_env_extra }}


### PR DESCRIPTION
Got this message from minio WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated. Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD